### PR TITLE
Disable Html for markdown

### DIFF
--- a/src/Website/Client/Pages/Home/ProductPage/ProductPage.razor.cs
+++ b/src/Website/Client/Pages/Home/ProductPage/ProductPage.razor.cs
@@ -66,7 +66,7 @@ namespace Website.Client.Pages.Home.ProductPage
 
                 foreach (MProductTab tab in Product.Tabs)
                 {
-                    tab.Content = MarkdownHelper.ParseToHtml(tab.Content, false);
+                    tab.Content = MarkdownHelper.ParseToHtml(tab.Content);
                 }
 
                 Product.RatingsCount = Product.Reviews.Count;

--- a/src/Website/Client/Pages/Seller/ProductPage/Components/TabsTab.razor
+++ b/src/Website/Client/Pages/Seller/ProductPage/Components/TabsTab.razor
@@ -34,7 +34,7 @@
 
             <div class="mb-3">
                 <label class="form-label">Content</label>
-                <MarkdownEditor @bind-Value="Tab.Content" EnableToolbar="false" DisableHtml="false" />
+                <MarkdownEditor @bind-Value="Tab.Content" EnableToolbar="false" />
             </div>
 
             <div class="mb-3 form-check">

--- a/src/Website/Client/Pages/User/CheckoutPage/CheckoutPage.razor.cs
+++ b/src/Website/Client/Pages/User/CheckoutPage/CheckoutPage.razor.cs
@@ -34,7 +34,7 @@ namespace Website.Client.Pages.User.CheckoutPage
             
             if (OrderParams != null)
             {
-                OrderParams.Seller.TermsAndConditions = MarkdownHelper.ParseToHtml(OrderParams.Seller.TermsAndConditions, false);
+                OrderParams.Seller.TermsAndConditions = MarkdownHelper.ParseToHtml(OrderParams.Seller.TermsAndConditions);
                 PaymentMethods = await HttpClient.GetFromJsonAsync<string[]>($"api/payments/{SellerId}");
                 if (string.IsNullOrEmpty(OrderParams.PaymentMethod))
                 {

--- a/src/Website/Client/Pages/User/SettingsPage/Components/SellerTab.razor
+++ b/src/Website/Client/Pages/User/SettingsPage/Components/SellerTab.razor
@@ -47,7 +47,7 @@
 
     <div class="mb-3">
         <label class="form-label">Terms & Conditions</label>
-        <MarkdownEditor @bind-Value="User.TermsAndConditions" EnableToolbar="false" DisableHtml="false" />
+        <MarkdownEditor @bind-Value="User.TermsAndConditions" EnableToolbar="false" />
         <div class="form-text">Terms & Conditions of purchasing your products</div>
     </div>
 


### PR DESCRIPTION
This disables html for the markdown editor so users and sellers are not able to write their custom html inside the editor

This has a **problem**. All the products and terms and conditions that were created with the old markdown editor will have to be converted from html to markdown. You can easily convert them using an online converter but it has to be done manually by the seller