### PR TITLE
Reduce final docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM bitnami/dotnet-sdk:latest
+FROM bitnami/dotnet-sdk:latest as build
+
 WORKDIR /app
 COPY . .
 
-RUN dotnet publish src/Website/Server/Website.Server.csproj -o /var/www/unturnedstore/app
+RUN dotnet publish src/Website/Server/Website.Server.csproj -o /app/compiled/unturnedstore/
 
-#FROM bitnami/dotnet-sdk:latest
+
+FROM mcr.microsoft.com/dotnet/sdk:latest
+
 EXPOSE 5000/tcp
 WORKDIR /var/www/unturnedstore/app
+COPY --from=build /app/compiled/unturnedstore/. /var/www/unturnedstore/app/.
+USER root
 
-#COPY --from=publish /app/unturnedstore/app/. .
-#USER root
+RUN dotnet dev-certs https
 
 CMD ["dotnet", "Website.Server.dll", "--urls=https://0.0.0.0:5000", "--environment=Production"]


### PR DESCRIPTION
Use multistage docker build with Microsoft's official dotnet sdk image to reduce filesize.
`dotnet dev-certs https` is also ran in order to keep the app working under current conditions.