### PR TITLE
Fixed Prerendered Image Meta Tag

### DIFF
--- a/src/Website/Server/Pages/Prerender/PrerenderedMetaTags.cs
+++ b/src/Website/Server/Pages/Prerender/PrerenderedMetaTags.cs
@@ -13,7 +13,7 @@ namespace Website.Server.Pages.Prerender
         {
             Title = Product.Name;
             Description = Product.Description;
-            Image = "api/images/" + Product.ImageId;
+            Image = "/api/images/" + Product.ImageId;
         }
     }
 }


### PR DESCRIPTION
SUPER SILLY. I know. Added a missing `/`